### PR TITLE
PAB-10853 Terraform Plan/Apply Always Shows Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 2.0.3
+## 2.0.4
 
-ENHANCEMENTS:
+BUG FIXES:
 
-* resource/britive_policy: Update timeOfAccess to include dateSchedule and daysSchedule
-* resource/britive_profile_policy: Update timeOfAccess to include dateSchedule and daysSchedule
+* provider: Terraform Plan/Apply Always Shows Changes (PAB-11776/PAB-10854)
+* resource/britive_policy,resource/britive_profile_policy: Terraform Provider gives whitespace changes diff for conditions under policy/profile-policy (PAB-10853)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Requirements
 ------------
 
 - [Terraform](https://www.terraform.io/downloads.html) >= 0.13.7+
-- [Go](https://golang.org/doc/install) >= 1.15
+- [Go](https://golang.org/doc/install) >= 1.16
 
 
 Using the provider

--- a/britive-client-go/client.go
+++ b/britive-client-go/client.go
@@ -552,7 +552,7 @@ func TimeOfAccessBlockEqual(old, new string) bool {
 					equalCount++
 				}
 			case "daysSchedule":
-				if reflect.DeepEqual(memOld, memNew) {
+				if DaysScheduleBlockEqual(string(memOld), string(memNew)) {
 					equalCount++
 				}
 			default:
@@ -577,4 +577,78 @@ func SliceIgnoreOrderEqual(old, new []string) bool {
 	sort.Strings(new)
 
 	return reflect.DeepEqual(old, new)
+}
+
+func DaysScheduleBlockEqual(old, new string) bool {
+	equalCount := 0
+
+	if old == emptyString {
+		old = "{}"
+	}
+
+	if new == emptyString {
+		new = "{}"
+	}
+
+	oldArray := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(old), &oldArray); err != nil {
+		panic(err)
+	}
+
+	newArray := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(new), &newArray); err != nil {
+		panic(err)
+	}
+
+	if len(oldArray) == len(newArray) {
+		for key, val := range oldArray {
+			memOld, err := json.Marshal(val)
+			if err != nil {
+				panic(err)
+			}
+			memNew, err := json.Marshal(newArray[key])
+			if err != nil {
+				panic(err)
+			}
+			switch key {
+			case "fromTime":
+				if string(memOld) == string(memNew) {
+					equalCount++
+				}
+			case "toTime":
+				if string(memOld) == string(memNew) {
+					equalCount++
+				}
+			case "timezone":
+				if string(memOld) == string(memNew) {
+					equalCount++
+				}
+			case "days":
+				oldDaysInterface := val.([]interface{})
+				newDaysInterface := newArray[key].([]interface{})
+
+				oldDaysSlice := make([]string, len(oldDaysInterface))
+				for i, v := range oldDaysInterface {
+					oldDaysSlice[i] = v.(string)
+				}
+				newDaysSlice := make([]string, len(newDaysInterface))
+				for i, v := range newDaysInterface {
+					newDaysSlice[i] = v.(string)
+				}
+
+				if SliceIgnoreOrderEqual(oldDaysSlice, newDaysSlice) {
+					equalCount++
+				}
+			default:
+				return false
+			}
+		}
+		if equalCount != len(newArray) {
+			return false
+		}
+	} else {
+		return false
+	}
+
+	return true
 }

--- a/britive-client-go/client.go
+++ b/britive-client-go/client.go
@@ -377,7 +377,7 @@ func ConditionEqual(old, new string) bool {
 					equalCount++
 				}
 			case "ipAddress":
-				if string(memOld) == string(memNew) {
+				if IPAddressBlockEqual(string(memOld), string(memNew)) {
 					equalCount++
 				}
 			case "timeOfAccess":
@@ -651,4 +651,21 @@ func DaysScheduleBlockEqual(old, new string) bool {
 	}
 
 	return true
+}
+
+func IPAddressBlockEqual(old, new string) bool {
+	oldSlice := strings.Split(old, ",")
+	newSlice := strings.Split(new, ",")
+	if len(oldSlice) != len(newSlice) {
+		return false
+	}
+	oldMap := make(map[string]int, len(oldSlice))
+	newMap := make(map[string]int, len(newSlice))
+	for _, v := range oldSlice {
+		oldMap[v]++
+	}
+	for _, v := range newSlice {
+		newMap[v]++
+	}
+	return reflect.DeepEqual(oldMap, newMap)
 }

--- a/britive-client-go/client.go
+++ b/britive-client-go/client.go
@@ -654,18 +654,26 @@ func DaysScheduleBlockEqual(old, new string) bool {
 }
 
 func IPAddressBlockEqual(old, new string) bool {
-	oldSlice := strings.Split(old, ",")
-	newSlice := strings.Split(new, ",")
-	if len(oldSlice) != len(newSlice) {
+
+	if old == emptyString {
+		old = ""
+	}
+
+	if new == emptyString {
+		new = ""
+	}
+
+	if len(old) != len(new) {
 		return false
 	}
-	oldMap := make(map[string]int, len(oldSlice))
-	newMap := make(map[string]int, len(newSlice))
-	for _, v := range oldSlice {
-		oldMap[v]++
-	}
-	for _, v := range newSlice {
-		newMap[v]++
-	}
-	return reflect.DeepEqual(oldMap, newMap)
+
+	old = strings.TrimPrefix(old, "\"")
+	new = strings.TrimPrefix(new, "\"")
+	old = strings.TrimSuffix(old, "\"")
+	new = strings.TrimSuffix(new, "\"")
+
+	oldSlice := strings.Split(strings.TrimSpace(old), ",")
+	newSlice := strings.Split(strings.TrimSpace(new), ",")
+
+	return SliceIgnoreOrderEqual(oldSlice, newSlice)
 }

--- a/britive-client-go/client.go
+++ b/britive-client-go/client.go
@@ -275,3 +275,65 @@ func ArrayOfMapsEqual(old, new string) bool {
 	}
 	return true
 }
+
+func MembersEqual(old, new string) bool {
+
+	equalCount := 0
+
+	if old == emptyString {
+		old = "{}"
+	}
+
+	if new == emptyString {
+		new = "{}"
+	}
+
+	var oldArray map[string][]map[string]interface{}
+	if err := json.Unmarshal([]byte(old), &oldArray); err != nil {
+		panic(err)
+	}
+
+	var newArray map[string][]map[string]interface{}
+	if err := json.Unmarshal([]byte(new), &newArray); err != nil {
+		panic(err)
+	}
+
+	if len(oldArray) == len(newArray) {
+		for key, val := range oldArray {
+			memOld, err := json.Marshal(val)
+			if err != nil {
+				panic(err)
+			}
+			memNew, err := json.Marshal(newArray[key])
+			if err != nil {
+				panic(err)
+			}
+			switch key {
+			case "serviceIdentities":
+				if ArrayOfMapsEqual(string(memOld), string(memNew)) {
+					equalCount++
+				}
+			case "tags":
+				if ArrayOfMapsEqual(string(memOld), string(memNew)) {
+					equalCount++
+				}
+			case "tokens":
+				if ArrayOfMapsEqual(string(memOld), string(memNew)) {
+					equalCount++
+				}
+			case "users":
+				if ArrayOfMapsEqual(string(memOld), string(memNew)) {
+					equalCount++
+				}
+			default:
+				return false
+			}
+		}
+		if equalCount != len(newArray) {
+			return false
+		}
+	} else {
+		return false
+	}
+	return true
+}

--- a/britive-client-go/client.go
+++ b/britive-client-go/client.go
@@ -41,7 +41,7 @@ func NewClient(apiBaseURL, token, version string) (*Client, error) {
 	return client, nil
 }
 
-//QueryRequest - godoc
+// QueryRequest - godoc
 type QueryRequest struct {
 	Client      *Client
 	QueryParams map[string]string
@@ -49,7 +49,7 @@ type QueryRequest struct {
 	Result      interface{}
 }
 
-//SortDirection - godoc
+// SortDirection - godoc
 type SortDirection string
 
 const (
@@ -59,7 +59,7 @@ const (
 	SortDirectionDescending SortDirection = "desc"
 )
 
-//WithQuery - godoc
+// WithQuery - godoc
 func (gpr *QueryRequest) WithQuery(query string) *QueryRequest {
 	if query != emptyString {
 		gpr.QueryParams["query"] = url.QueryEscape(query)
@@ -67,7 +67,7 @@ func (gpr *QueryRequest) WithQuery(query string) *QueryRequest {
 	return gpr
 }
 
-//WithFilter - godoc
+// WithFilter - godoc
 func (gpr *QueryRequest) WithFilter(filter string) *QueryRequest {
 	if filter != emptyString {
 		gpr.QueryParams["filter"] = url.QueryEscape(filter)
@@ -75,7 +75,7 @@ func (gpr *QueryRequest) WithFilter(filter string) *QueryRequest {
 	return gpr
 }
 
-//WithSort - godoc
+// WithSort - godoc
 func (gpr *QueryRequest) WithSort(name string, direction SortDirection) *QueryRequest {
 	if name != emptyString && direction != emptyString {
 		gpr.QueryParams["sort"] = fmt.Sprintf("%s,%s", name, direction)
@@ -83,7 +83,7 @@ func (gpr *QueryRequest) WithSort(name string, direction SortDirection) *QueryRe
 	return gpr
 }
 
-//WithSize - godoc
+// WithSize - godoc
 func (gpr *QueryRequest) WithSize(size int) *QueryRequest {
 	if size > 0 {
 		gpr.QueryParams["size"] = strconv.Itoa(size)
@@ -91,13 +91,13 @@ func (gpr *QueryRequest) WithSize(size int) *QueryRequest {
 	return gpr
 }
 
-//WithLock - godoc
+// WithLock - godoc
 func (gpr *QueryRequest) WithLock(lock string) *QueryRequest {
 	gpr.Lock = lock
 	return gpr
 }
 
-//WithResult - godoc
+// WithResult - godoc
 func (gpr *QueryRequest) WithResult(result interface{}) *QueryRequest {
 	gpr.Result = result
 	return gpr
@@ -111,7 +111,7 @@ func (c *Client) NewQueryRequest() *QueryRequest {
 	}
 }
 
-//Query - godoc
+// Query - godoc
 func (gpr *QueryRequest) Query(endpoint string) error {
 	const size = 10
 	var page = 0
@@ -168,14 +168,14 @@ func (gpr *QueryRequest) Query(endpoint string) error {
 	return nil
 }
 
-//DoWithLock - Perform Britive API call with lock
+// DoWithLock - Perform Britive API call with lock
 func (c *Client) DoWithLock(req *http.Request, key string) ([]byte, error) {
 	c.lock(key)
 	defer c.unlock(key)
 	return c.Do(req)
 }
 
-//Do - Perform Britive API call
+// Do - Perform Britive API call
 func (c *Client) Do(req *http.Request) ([]byte, error) {
 	req.Header.Set("Authorization", fmt.Sprintf("TOKEN %s", c.Token))
 	req.Header.Set("Content-Type", "application/json")
@@ -213,7 +213,7 @@ func (c *Client) Do(req *http.Request) ([]byte, error) {
 	return body, err
 }
 
-//Lock to lock based on key
+// Lock to lock based on key
 func (c *Client) lock(key interface{}) {
 	mutex := &sync.Mutex{}
 	actual, _ := c.SyncMap.LoadOrStore(key, mutex)
@@ -226,7 +226,7 @@ func (c *Client) lock(key interface{}) {
 	}
 }
 
-//Unlock to unlock based on key
+// Unlock to unlock based on key
 func (c *Client) unlock(key interface{}) {
 	actual, exist := c.SyncMap.Load(key)
 	if !exist {
@@ -235,4 +235,43 @@ func (c *Client) unlock(key interface{}) {
 	actualMutex := actual.(*sync.Mutex)
 	c.SyncMap.Delete(key)
 	actualMutex.Unlock()
+}
+
+func ArrayOfMapsEqual(old, new string) bool {
+
+	equalCount := 0
+
+	if old == emptyString {
+		old = "[]"
+	}
+
+	if new == emptyString {
+		new = "[]"
+	}
+
+	oldArray := []map[string]interface{}{}
+	if err := json.Unmarshal([]byte(old), &oldArray); err != nil {
+		panic(err)
+	}
+
+	newArray := []map[string]interface{}{}
+	if err := json.Unmarshal([]byte(new), &newArray); err != nil {
+		panic(err)
+	}
+
+	if len(oldArray) == len(newArray) {
+		for _, v := range oldArray {
+			for _, p := range newArray {
+				if reflect.DeepEqual(v, p) {
+					equalCount++
+				}
+			}
+		}
+		if equalCount != len(newArray) {
+			return false
+		}
+	} else {
+		return false
+	}
+	return true
 }

--- a/britive-client-go/client.go
+++ b/britive-client-go/client.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"reflect"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -336,4 +337,244 @@ func MembersEqual(old, new string) bool {
 		return false
 	}
 	return true
+}
+
+func ConditionEqual(old, new string) bool {
+
+	equalCount := 0
+
+	if old == emptyString {
+		old = "{}"
+	}
+
+	if new == emptyString {
+		new = "{}"
+	}
+
+	var oldArray map[string]interface{}
+	if err := json.Unmarshal([]byte(old), &oldArray); err != nil {
+		panic(err)
+	}
+
+	var newArray map[string]interface{}
+	if err := json.Unmarshal([]byte(new), &newArray); err != nil {
+		panic(err)
+	}
+
+	if len(oldArray) == len(newArray) {
+		for key, val := range oldArray {
+			memOld, err := json.Marshal(val)
+			if err != nil {
+				panic(err)
+			}
+			memNew, err := json.Marshal(newArray[key])
+			if err != nil {
+				panic(err)
+			}
+			switch key {
+			case "approval":
+				if ApprovalBlockEqual(string(memOld), string(memNew)) {
+					equalCount++
+				}
+			case "ipAddress":
+				if string(memOld) == string(memNew) {
+					equalCount++
+				}
+			case "timeOfAccess":
+				if TimeOfAccessBlockEqual(string(memOld), string(memNew)) {
+					equalCount++
+				}
+			default:
+				return false
+			}
+		}
+		if equalCount != len(newArray) {
+			return false
+		}
+	} else {
+		return false
+	}
+
+	return true
+}
+
+func ApprovalBlockEqual(old, new string) bool {
+
+	equalCount := 0
+
+	if old == emptyString {
+		old = "{}"
+	}
+
+	if new == emptyString {
+		new = "{}"
+	}
+
+	var oldArray map[string]interface{}
+	if err := json.Unmarshal([]byte(old), &oldArray); err != nil {
+		panic(err)
+	}
+
+	var newArray map[string]interface{}
+	if err := json.Unmarshal([]byte(new), &newArray); err != nil {
+		panic(err)
+	}
+
+	if len(oldArray) == len(newArray) {
+		for key, val := range oldArray {
+			memOld, err := json.Marshal(val)
+			if err != nil {
+				panic(err)
+			}
+			memNew, err := json.Marshal(newArray[key])
+			if err != nil {
+				panic(err)
+			}
+			switch key {
+			case "approvers":
+				if ApproversBlockEqual(string(memOld), string(memNew)) {
+					equalCount++
+				}
+			case "isValidForInDays":
+				if string(memOld) == string(memNew) {
+					equalCount++
+				}
+			case "notificationMedium":
+				if string(memOld) == string(memNew) {
+					equalCount++
+				}
+			case "timeToApprove":
+				if string(memOld) == string(memNew) {
+					equalCount++
+				}
+			case "validFor":
+				if string(memOld) == string(memNew) {
+					equalCount++
+				}
+			default:
+				return false
+			}
+		}
+		if equalCount != len(newArray) {
+			return false
+		}
+	} else {
+		return false
+	}
+
+	return true
+}
+
+func ApproversBlockEqual(old, new string) bool {
+	equalCount := 0
+
+	if old == emptyString {
+		old = "{}"
+	}
+
+	if new == emptyString {
+		new = "{}"
+	}
+
+	oldArray := make(map[string][]string)
+	if err := json.Unmarshal([]byte(old), &oldArray); err != nil {
+		panic(err)
+	}
+
+	newArray := make(map[string][]string)
+	if err := json.Unmarshal([]byte(new), &newArray); err != nil {
+		panic(err)
+	}
+
+	if len(oldArray) == len(newArray) {
+		for key, val := range oldArray {
+			switch key {
+			case "tags":
+				if SliceIgnoreOrderEqual(val, newArray[key]) {
+					equalCount++
+				}
+			case "userIds":
+				if SliceIgnoreOrderEqual(val, newArray[key]) {
+					equalCount++
+				}
+			case "channelIds":
+				if SliceIgnoreOrderEqual(val, newArray[key]) {
+					equalCount++
+				}
+			default:
+				return false
+			}
+		}
+		if equalCount != len(newArray) {
+			return false
+		}
+	} else {
+		return false
+	}
+
+	return true
+}
+
+func TimeOfAccessBlockEqual(old, new string) bool {
+	equalCount := 0
+
+	if old == emptyString {
+		old = "{}"
+	}
+
+	if new == emptyString {
+		new = "{}"
+	}
+
+	var oldArray map[string]interface{}
+	if err := json.Unmarshal([]byte(old), &oldArray); err != nil {
+		panic(err)
+	}
+
+	var newArray map[string]interface{}
+	if err := json.Unmarshal([]byte(new), &newArray); err != nil {
+		panic(err)
+	}
+
+	if len(oldArray) == len(newArray) {
+		for key, val := range oldArray {
+			memOld, err := json.Marshal(val)
+			if err != nil {
+				panic(err)
+			}
+			memNew, err := json.Marshal(newArray[key])
+			if err != nil {
+				panic(err)
+			}
+			switch key {
+			case "dateSchedule":
+				if reflect.DeepEqual(memOld, memNew) {
+					equalCount++
+				}
+			case "daysSchedule":
+				if reflect.DeepEqual(memOld, memNew) {
+					equalCount++
+				}
+			default:
+				return false
+			}
+		}
+		if equalCount != len(newArray) {
+			return false
+		}
+	} else {
+		return false
+	}
+
+	return true
+}
+
+func SliceIgnoreOrderEqual(old, new []string) bool {
+	if len(old) != len(new) {
+		return false
+	}
+	sort.Strings(old)
+	sort.Strings(new)
+
+	return reflect.DeepEqual(old, new)
 }

--- a/britive/resource_permission.go
+++ b/britive/resource_permission.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-//ResourcePermission - Terraform Resource for Permission
+// ResourcePermission - Terraform Resource for Permission
 type ResourcePermission struct {
 	Resource     *schema.Resource
 	helper       *ResourcePermissionHelper
@@ -20,7 +20,7 @@ type ResourcePermission struct {
 	importHelper *ImportHelper
 }
 
-//NewResourcePermission - Initializes new permission resource
+// NewResourcePermission - Initializes new permission resource
 func NewResourcePermission(v *Validation, importHelper *ImportHelper) *ResourcePermission {
 	rp := &ResourcePermission{
 		helper:       NewResourcePermissionHelper(),
@@ -52,7 +52,7 @@ func NewResourcePermission(v *Validation, importHelper *ImportHelper) *ResourceP
 				Description: "The consumer service",
 			},
 			"resources": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Required:    true,
 				Description: "Comma separated list of resources",
 				Elem: &schema.Schema{
@@ -60,7 +60,7 @@ func NewResourcePermission(v *Validation, importHelper *ImportHelper) *ResourceP
 				},
 			},
 			"actions": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Required:    true,
 				Description: "Actions to be performed on the resource",
 				Elem: &schema.Schema{
@@ -199,11 +199,11 @@ func (rp *ResourcePermission) resourceStateImporter(d *schema.ResourceData, m in
 
 //endregion
 
-//ResourcePermissionHelper - Resource Permission helper functions
+// ResourcePermissionHelper - Resource Permission helper functions
 type ResourcePermissionHelper struct {
 }
 
-//NewResourcePermissionsHelper - Initializes new permission resource helper
+// NewResourcePermissionsHelper - Initializes new permission resource helper
 func NewResourcePermissionHelper() *ResourcePermissionHelper {
 	return &ResourcePermissionHelper{}
 }
@@ -216,11 +216,11 @@ func (rph *ResourcePermissionHelper) mapResourceToModel(d *schema.ResourceData, 
 	permission.Description = d.Get("description").(string)
 	permission.Consumer = d.Get("consumer").(string)
 
-	res := d.Get("resources").([]interface{})
-	permission.Resources = append(permission.Resources, res...)
+	res := d.Get("resources").(*schema.Set)
+	permission.Resources = append(permission.Resources, res.List()...)
 
-	act := d.Get("actions").([]interface{})
-	permission.Actions = append(permission.Actions, act...)
+	act := d.Get("actions").(*schema.Set)
+	permission.Actions = append(permission.Actions, act.List()...)
 
 	return nil
 }

--- a/britive/resource_policy.go
+++ b/britive/resource_policy.go
@@ -76,6 +76,9 @@ func NewResourcePolicy(importHelper *ImportHelper) *ResourcePolicy {
 				Optional:     true,
 				Description:  "Members of the policy",
 				ValidateFunc: validation.StringIsNotWhiteSpace,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return britive.MembersEqual(old, new)
+				},
 			},
 			"condition": {
 				Type:         schema.TypeString,

--- a/britive/resource_policy.go
+++ b/britive/resource_policy.go
@@ -14,14 +14,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-//ResourcePolicy - Terraform Resource for Policy
+// ResourcePolicy - Terraform Resource for Policy
 type ResourcePolicy struct {
 	Resource     *schema.Resource
 	helper       *ResourcePolicyHelper
 	importHelper *ImportHelper
 }
 
-//NewResourcePolicy - Initialization of new policy resource
+// NewResourcePolicy - Initialization of new policy resource
 func NewResourcePolicy(importHelper *ImportHelper) *ResourcePolicy {
 	rp := &ResourcePolicy{
 		helper:       NewResourcePolicyHelper(),
@@ -88,12 +88,18 @@ func NewResourcePolicy(importHelper *ImportHelper) *ResourcePolicy {
 				Optional:     true,
 				Description:  "Permissions of the policy",
 				ValidateFunc: validation.StringIsNotWhiteSpace,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return britive.ArrayOfMapsEqual(old, new)
+				},
 			},
 			"roles": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Description:  "Roles of the policy",
 				ValidateFunc: validation.StringIsNotWhiteSpace,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return britive.ArrayOfMapsEqual(old, new)
+				},
 			},
 		},
 	}
@@ -227,11 +233,11 @@ func (rp *ResourcePolicy) resourceStateImporter(d *schema.ResourceData, m interf
 
 //endregion
 
-//ResourceProfilePolicyHelper - Terraform Resource for Policy Helper
+// ResourceProfilePolicyHelper - Terraform Resource for Policy Helper
 type ResourcePolicyHelper struct {
 }
 
-//NewResourcePolicyHelper - Initialization of new policy resource helper
+// NewResourcePolicyHelper - Initialization of new policy resource helper
 func NewResourcePolicyHelper() *ResourcePolicyHelper {
 	return &ResourcePolicyHelper{}
 }

--- a/britive/resource_policy.go
+++ b/britive/resource_policy.go
@@ -85,6 +85,9 @@ func NewResourcePolicy(importHelper *ImportHelper) *ResourcePolicy {
 				Optional:     true,
 				Description:  "Condition of the policy",
 				ValidateFunc: validation.StringIsNotWhiteSpace,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return britive.ConditionEqual(old, new)
+				},
 			},
 			"permissions": {
 				Type:         schema.TypeString,

--- a/britive/resource_profile.go
+++ b/britive/resource_profile.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-//ResourceProfile - Terraform Resource for Profile
+// ResourceProfile - Terraform Resource for Profile
 type ResourceProfile struct {
 	Resource     *schema.Resource
 	helper       *ResourceProfileHelper
@@ -21,7 +21,7 @@ type ResourceProfile struct {
 	importHelper *ImportHelper
 }
 
-//NewResourceProfile - Initialization of new profile resource
+// NewResourceProfile - Initialization of new profile resource
 func NewResourceProfile(v *Validation, importHelper *ImportHelper) *ResourceProfile {
 	rp := &ResourceProfile{
 		helper:       NewResourceProfileHelper(),
@@ -68,7 +68,7 @@ func NewResourceProfile(v *Validation, importHelper *ImportHelper) *ResourceProf
 				Description: "To disable the Britive profile",
 			},
 			"associations": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Required:    true,
 				Description: "The list of associations for the Britive profile",
 				Elem: &schema.Resource{
@@ -301,12 +301,12 @@ func (rp *ResourceProfile) resourceStateImporter(d *schema.ResourceData, m inter
 
 //endregion
 
-//ResourceProfileHelper - Resource Profile helper functions
+// ResourceProfileHelper - Resource Profile helper functions
 type ResourceProfileHelper struct {
 	Resource *schema.Resource
 }
 
-//NewResourceProfileHelper - Initialization of new profile resource helper
+// NewResourceProfileHelper - Initialization of new profile resource helper
 func NewResourceProfileHelper() *ResourceProfileHelper {
 	return &ResourceProfileHelper{}
 }
@@ -332,9 +332,9 @@ func (rph *ResourceProfileHelper) saveProfileAssociations(appContainerID string,
 	}
 	associationScopes := make([]britive.ProfileAssociation, 0)
 	associationResources := make([]britive.ProfileAssociation, 0)
-	as := d.Get("associations").([]interface{})
+	as := d.Get("associations").(*schema.Set)
 	unmatchedAssociations := make([]interface{}, 0)
-	for _, a := range as {
+	for _, a := range as.List() {
 		s := a.(map[string]interface{})
 		associationType := s["type"].(string)
 		associationValue := s["value"].(string)
@@ -516,7 +516,7 @@ func (rph *ResourceProfileHelper) mapProfileAssociationsModelToResource(appConta
 	if len(associations) == 0 || appRootEnvironmentGroup == nil {
 		return make([]interface{}, 0), nil
 	}
-	inputAssociations := d.Get("associations").([]interface{})
+	inputAssociations := d.Get("associations").(*schema.Set)
 	profileAssociations := make([]interface{}, 0)
 	for _, association := range associations {
 		var rootAssociations []britive.Association
@@ -539,7 +539,7 @@ func (rph *ResourceProfileHelper) mapProfileAssociationsModelToResource(appConta
 			}
 			profileAssociation := make(map[string]interface{})
 			associationValue := a.Name
-			for _, inputAssociation := range inputAssociations {
+			for _, inputAssociation := range inputAssociations.List() {
 				ia := inputAssociation.(map[string]interface{})
 				iat := ia["type"].(string)
 				iav := ia["value"].(string)

--- a/britive/resource_profile_policy.go
+++ b/britive/resource_profile_policy.go
@@ -14,14 +14,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-//ResourceProfilePolicy - Terraform Resource for Profile Policy
+// ResourceProfilePolicy - Terraform Resource for Profile Policy
 type ResourceProfilePolicy struct {
 	Resource     *schema.Resource
 	helper       *ResourceProfilePolicyHelper
 	importHelper *ImportHelper
 }
 
-//NewResourceProfilePolicy - Initialization of new profile policy resource
+// NewResourceProfilePolicy - Initialization of new profile policy resource
 func NewResourceProfilePolicy(importHelper *ImportHelper) *ResourceProfilePolicy {
 	rpp := &ResourceProfilePolicy{
 		helper:       NewResourceProfilePolicyHelper(),
@@ -89,6 +89,9 @@ func NewResourceProfilePolicy(importHelper *ImportHelper) *ResourceProfilePolicy
 				Optional:     true,
 				Description:  "Members of the policy",
 				ValidateFunc: validation.StringIsNotWhiteSpace,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return britive.MembersEqual(old, new)
+				},
 			},
 			"condition": {
 				Type:         schema.TypeString,
@@ -233,11 +236,11 @@ func (rpp *ResourceProfilePolicy) resourceStateImporter(d *schema.ResourceData, 
 
 //endregion
 
-//ResourceProfilePolicyHelper - Terraform Resource for Profile Policy Helper
+// ResourceProfilePolicyHelper - Terraform Resource for Profile Policy Helper
 type ResourceProfilePolicyHelper struct {
 }
 
-//NewResourceProfilePolicyHelper - Initialization of new profile policy resource helper
+// NewResourceProfilePolicyHelper - Initialization of new profile policy resource helper
 func NewResourceProfilePolicyHelper() *ResourceProfilePolicyHelper {
 	return &ResourceProfilePolicyHelper{}
 }

--- a/britive/resource_profile_policy.go
+++ b/britive/resource_profile_policy.go
@@ -98,6 +98,9 @@ func NewResourceProfilePolicy(importHelper *ImportHelper) *ResourceProfilePolicy
 				Optional:     true,
 				Description:  "Condition of the policy",
 				ValidateFunc: validation.StringIsNotWhiteSpace,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return britive.ConditionEqual(old, new)
+				},
 			},
 		},
 	}

--- a/britive/resource_role.go
+++ b/britive/resource_role.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-//ResourceRole - Terraform Resource for Role
+// ResourceRole - Terraform Resource for Role
 type ResourceRole struct {
 	Resource     *schema.Resource
 	helper       *ResourceRoleHelper
@@ -22,7 +22,7 @@ type ResourceRole struct {
 	importHelper *ImportHelper
 }
 
-//NewResourceRole - Initializes new role resource
+// NewResourceRole - Initializes new role resource
 func NewResourceRole(v *Validation, importHelper *ImportHelper) *ResourceRole {
 	rr := &ResourceRole{
 		helper:       NewResourceRoleHelper(),
@@ -53,6 +53,9 @@ func NewResourceRole(v *Validation, importHelper *ImportHelper) *ResourceRole {
 				Required:     true,
 				Description:  "Permissions of the role",
 				ValidateFunc: validation.StringIsNotWhiteSpace,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return britive.ArrayOfMapsEqual(old, new)
+				},
 			},
 		},
 	}
@@ -187,11 +190,11 @@ func (rr *ResourceRole) resourceStateImporter(d *schema.ResourceData, m interfac
 
 //endregion
 
-//ResourceRoleHelper - Resource Role helper functions
+// ResourceRoleHelper - Resource Role helper functions
 type ResourceRoleHelper struct {
 }
 
-//NewResourceRoleHelper - Initializes new role resource helper
+// NewResourceRoleHelper - Initializes new role resource helper
 func NewResourceRoleHelper() *ResourceRoleHelper {
 	return &ResourceRoleHelper{}
 }


### PR DESCRIPTION
Changes to fix the noise caused by the diff when doing terraform plan/apply, even without making any changes to the config file. The resources/modules fixed are:
Profile - Associations 
Permissions - Resources
Permissions -  Actions
Roles -  Permissions
Policy -  Permissions
Policy - Roles
Policy  - Approvers
Policy - Members
Policy - DaysSchedule
Policy - IPAddress
ProfilePolicy - Approvers
ProfilePolicy - Members
ProfilePolicy - DaysSchedule
ProfilePolicy - IPAddress