### PR TITLE
ITSD-2148 Terraform release TF 2.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 2.0.5
+## 2.0.6
 
 BUG FIXES:
 
-* resource/britive_profile_policy: Unable to change profile policy name from terraform (PAB-13105)
+* resource/britive_profile: Diff shown for all associations, when one association is added or removed (PAB-13057)
+* resource/britive_profile: Documentation update, specifying to not use extendable properties for AWS profiles (PAB-13483)

--- a/britive/resource_profile.go
+++ b/britive/resource_profile.go
@@ -88,6 +88,7 @@ func NewResourceProfile(v *Validation, importHelper *ImportHelper) *ResourceProf
 						"parent_name": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							Default:     "",
 							Description: "The parent name of the resource. Required only if the association type is ApplicationResource",
 						},
 					},

--- a/docs/resources/profile.md
+++ b/docs/resources/profile.md
@@ -40,6 +40,12 @@ The following arguments are supported:
 
 * `expiration_duration` - (Required) The expiration time for the Britive profile. For example, `25m0s`
 
+* `destination_url` - (Optional) The console URL where the user will be redirected upon checking out the profile. For example: `https://console.aws.amazon.com`
+
+* `associations` - (Required) The list of associations for the Britive profile.
+
+The following arguments are supported, except for AWS profiles:
+
 * `extendable` - (Optional) The Boolean flag that indicates whether profile expiry is extendable or not. The default value is `false`.
 
 * `notification_prior_to_expiration` - (Optional) The Britive profile expiry notification as a time value. For example, `10m0s`
@@ -48,11 +54,7 @@ The following arguments are supported:
 
 * `extension_limit` - (Optional) The Britive profile expiry extension limit. For example: `2`
 
-* `destination_url` - (Optional) The console URL where the user will be redirected upon checking out the profile. For example: `https://console.aws.amazon.com`
-
-* `associations` - (Required) The list of associations for the Britive profile.
-
-  The format of `associations` is documented below.
+The format of `associations` is documented below.
 
 ### `associations` block supports
 


### PR DESCRIPTION
Fixes for 
Diff is shown for all associations when one association is added or removed (PAB-13057)
Documentation update, specifying to not use extendable properties for AWS profiles (PAB-13483)