### PR TITLE
Add optional API response caching and HTTP 429 retry handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.3.0
+
+FEATURES:
+* **API Response Caching:** New optional `enable_cache` provider attribute to enable in-memory caching of frequently accessed API responses (root environment group, application environments, application type). Reduces redundant GET calls during plan/apply for configurations with many profiles and policies. Can be configured via provider block, `BRITIVE_CACHE` environment variable, or config file.
+
+ENHANCEMENTS:
+* **HTTP 429 Retry Handling:** The provider now automatically retries API requests that receive an HTTP 429 (Too Many Requests) response, respecting the `Retry-After` header from the Britive platform. Requests are retried up to 5 times with exponential backoff as a fallback. This is always enabled and requires no configuration.
+
 ## 2.2.9
 
 FEATURES:

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ $ make build
 Developing the provider
 ---------------------------
 
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org)
+If you wish to work on the provider, you'll first need [Go](https://www.golang.org)
 installed on your machine (version 1.15.0+ is *required*). You can use [goenv](https://github.com/syndbg/goenv)
-to manage your Go version. You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH),
+to manage your Go version. You'll also need to correctly setup a [GOPATH](https://golang.org/doc/code.html#GOPATH),
 as well as adding `$GOPATH/bin` to your `$PATH`.
 
 To compile the provider, run `make build`.

--- a/britive-client-go/application-root-environment-group.go
+++ b/britive-client-go/application-root-environment-group.go
@@ -8,6 +8,17 @@ import (
 
 // GetApplicationRootEnvironmentGroup - Returns root environment group
 func (c *Client) GetApplicationRootEnvironmentGroup(appContainerID string) (*ApplicationRootEnvironmentGroup, error) {
+	cacheKey := fmt.Sprintf("root-env-group:%s", appContainerID)
+	if cached, ok := c.cacheGet(cacheKey); ok {
+		original := cached.(*ApplicationRootEnvironmentGroup)
+		cp := *original
+		cp.EnvironmentGroups = make([]Association, len(original.EnvironmentGroups))
+		copy(cp.EnvironmentGroups, original.EnvironmentGroups)
+		cp.Environments = make([]Association, len(original.Environments))
+		copy(cp.Environments, original.Environments)
+		return &cp, nil
+	}
+
 	//TODO: Warning Recursion - Get by Filter
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/apps/%s/root-environment-group", c.APIBaseURL, appContainerID), nil)
 	if err != nil {
@@ -25,5 +36,6 @@ func (c *Client) GetApplicationRootEnvironmentGroup(appContainerID string) (*App
 		return nil, err
 	}
 
+	c.cacheSet(cacheKey, applicationRootEnvironmentGroup)
 	return applicationRootEnvironmentGroup, nil
 }

--- a/britive-client-go/application.go
+++ b/britive-client-go/application.go
@@ -88,6 +88,14 @@ func (c *Client) GetApplicationByName(name string) (*Application, error) {
 }
 
 func (c *Client) GetAppEnvs(appId string, envType string) ([]ApplicationEnvironment, error) {
+	cacheKey := fmt.Sprintf("app-envs:%s:%s", appId, envType)
+	if cached, ok := c.cacheGet(cacheKey); ok {
+		original := cached.([]ApplicationEnvironment)
+		cp := make([]ApplicationEnvironment, len(original))
+		copy(cp, original)
+		return cp, nil
+	}
+
 	resourceURL := fmt.Sprintf("%s/apps/%s/root-environment-group?view=summary&type=%s", c.APIBaseURL, appId, envType)
 	req, err := http.NewRequest("GET", resourceURL, nil)
 	if err != nil {
@@ -114,6 +122,7 @@ func (c *Client) GetAppEnvs(appId string, envType string) ([]ApplicationEnvironm
 		return nil, ErrNotFound
 	}
 
+	c.cacheSet(cacheKey, appEnvs)
 	return appEnvs, nil
 }
 
@@ -242,6 +251,11 @@ func (c *Client) CreateRootEnvironmentGroup(applicationID string, catalogAppId i
 			return err
 		}
 
+		c.CacheEvict(
+			fmt.Sprintf("root-env-group:%s", applicationID),
+			fmt.Sprintf("app-envs:%s:environments", applicationID),
+			fmt.Sprintf("app-envs:%s:environmentGroups", applicationID),
+		)
 	}
 	return nil
 }
@@ -256,6 +270,12 @@ func (c *Client) DeleteApplication(applicationID string) error {
 
 	_, err = c.DoWithLock(req, applicationLockName)
 	if errors.Is(err, ErrNoContent) || err == nil {
+		c.CacheEvict(
+			fmt.Sprintf("root-env-group:%s", applicationID),
+			fmt.Sprintf("app-envs:%s:environments", applicationID),
+			fmt.Sprintf("app-envs:%s:environmentGroups", applicationID),
+			fmt.Sprintf("app-type:%s", applicationID),
+		)
 		return nil
 	}
 	return err
@@ -288,7 +308,7 @@ func (c *Client) GetRootEnvID(applicationID string) (string, error) {
 			return envGrp["id"], err
 		}
 	}
-	return "", errors.New("No root Environment Group ia available for application" + applicationID)
+	return "", errors.New("No root Environment Group is available for application " + applicationID)
 }
 
 // SystemAppPropertyType represents a property type in the system app catalog

--- a/britive-client-go/client.go
+++ b/britive-client-go/client.go
@@ -1,9 +1,13 @@
 package britive
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
+	"math"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -12,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 var (
@@ -21,25 +26,54 @@ var (
 
 // Client - Britive API client
 type Client struct {
-	APIBaseURL string
-	HTTPClient *http.Client
-	Token      string
-	Version    string
-	SyncMap    *sync.Map
+	APIBaseURL   string
+	HTTPClient   *http.Client
+	Token        string
+	Version      string
+	SyncMap      *sync.Map
+	Cache        *sync.Map
+	CacheEnabled bool
+	MaxRetries   int
 }
 
 // NewClient - Initializes new Britive API client
-func NewClient(apiBaseURL, token, version string) (*Client, error) {
+func NewClient(apiBaseURL, token, version string, cacheEnabled bool) (*Client, error) {
 	syncOnce.Do(func() {
 		client = &Client{
-			HTTPClient: &http.Client{Timeout: 0},
-			APIBaseURL: apiBaseURL,
-			Token:      token,
-			Version:    version,
-			SyncMap:    &sync.Map{},
+			HTTPClient:   &http.Client{Timeout: 0},
+			APIBaseURL:   apiBaseURL,
+			Token:        token,
+			Version:      version,
+			SyncMap:      &sync.Map{},
+			Cache:        &sync.Map{},
+			CacheEnabled: cacheEnabled,
+			MaxRetries:   5,
 		}
 	})
 	return client, nil
+}
+
+// cacheGet retrieves a cached value by key. Returns (nil, false) if caching is disabled or key not found.
+func (c *Client) cacheGet(key string) (interface{}, bool) {
+	if !c.CacheEnabled {
+		return nil, false
+	}
+	return c.Cache.Load(key)
+}
+
+// cacheSet stores a value in the cache. No-op if caching is disabled.
+func (c *Client) cacheSet(key string, value interface{}) {
+	if !c.CacheEnabled {
+		return
+	}
+	c.Cache.Store(key, value)
+}
+
+// CacheEvict removes the specified keys from the cache.
+func (c *Client) CacheEvict(keys ...string) {
+	for _, key := range keys {
+		c.Cache.Delete(key)
+	}
 }
 
 // QueryRequest - godoc
@@ -176,42 +210,89 @@ func (c *Client) DoWithLock(req *http.Request, key string) ([]byte, error) {
 	return c.Do(req)
 }
 
-// Do - Perform Britive API call
+// Do - Perform Britive API call with automatic retry on HTTP 429 (Too Many Requests)
 func (c *Client) Do(req *http.Request) ([]byte, error) {
+	// Buffer the request body so it can be replayed on retries
+	var bodyBytes []byte
+	if req.Body != nil {
+		var err error
+		bodyBytes, err = ioutil.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		req.Body.Close()
+	}
+
 	req.Header.Set("Authorization", fmt.Sprintf("TOKEN %s", c.Token))
 	req.Header.Set("Content-Type", "application/json")
 	userAgent := fmt.Sprintf("britive-client-go/%s golang/%s %s/%s britive-terraform/%s", c.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH, c.Version)
 	req.Header.Add("User-Agent", userAgent)
 
-	res, err := c.HTTPClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode == http.StatusNoContent {
-		return []byte(emptyString), ErrNoContent
-	}
-
-	body, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if res.StatusCode == http.StatusNotFound {
-		return body, ErrNotFound
-	}
-
-	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated && res.StatusCode != http.StatusAccepted {
-		var httpErrorResponse HTTPErrorResponse
-		err = json.Unmarshal(body, &httpErrorResponse)
-		if err == nil && httpErrorResponse.Message != emptyString {
-			return nil, fmt.Errorf("%s: %s", httpErrorResponse.ErrorCode, httpErrorResponse.Message)
+	for attempt := 0; ; attempt++ {
+		// Reset the request body for each attempt
+		if bodyBytes != nil {
+			req.Body = ioutil.NopCloser(bytes.NewReader(bodyBytes))
+		} else {
+			req.Body = nil
 		}
-		return nil, fmt.Errorf("an error occurred while processing the request\nrequest url: %s\nrequest method: %s\nresponse status: %d\nresponse body: %s", req.URL, req.Method, res.StatusCode, body)
-	}
 
-	return body, err
+		res, err := c.HTTPClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		body, err := ioutil.ReadAll(res.Body)
+		res.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		// Handle 429 Too Many Requests with retry
+		if res.StatusCode == http.StatusTooManyRequests {
+			if attempt >= c.MaxRetries {
+				return nil, fmt.Errorf("rate limited: max retries (%d) exceeded for request %s %s", c.MaxRetries, req.Method, req.URL)
+			}
+
+			wait := retryAfterDuration(res, attempt)
+			log.Printf("[WARN] Rate limited (HTTP 429) on %s %s, retrying in %v (attempt %d/%d)", req.Method, req.URL, wait, attempt+1, c.MaxRetries)
+			time.Sleep(wait)
+			continue
+		}
+
+		if res.StatusCode == http.StatusNoContent {
+			return []byte(emptyString), ErrNoContent
+		}
+
+		if res.StatusCode == http.StatusNotFound {
+			return body, ErrNotFound
+		}
+
+		if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated && res.StatusCode != http.StatusAccepted {
+			var httpErrorResponse HTTPErrorResponse
+			err = json.Unmarshal(body, &httpErrorResponse)
+			if err == nil && httpErrorResponse.Message != emptyString {
+				return nil, fmt.Errorf("%s: %s", httpErrorResponse.ErrorCode, httpErrorResponse.Message)
+			}
+			return nil, fmt.Errorf("an error occurred while processing the request\nrequest url: %s\nrequest method: %s\nresponse status: %d\nresponse body: %s", req.URL, req.Method, res.StatusCode, body)
+		}
+
+		return body, nil
+	}
+}
+
+// retryAfterDuration parses the Retry-After header from the response.
+// If the header is present and contains a valid number of seconds, that value is used.
+// Otherwise, falls back to exponential backoff: 2^attempt seconds (capped at 30s) with jitter.
+func retryAfterDuration(res *http.Response, attempt int) time.Duration {
+	if retryAfter := res.Header.Get("Retry-After"); retryAfter != emptyString {
+		if seconds, err := strconv.Atoi(retryAfter); err == nil && seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+	}
+	// Exponential backoff with jitter as fallback
+	backoff := math.Min(float64(int(1)<<uint(attempt)), 30)
+	jitter := rand.Float64() * 0.5 * backoff
+	return time.Duration(backoff+jitter) * time.Second
 }
 
 // Lock to lock based on key

--- a/britive-client-go/entity-environment.go
+++ b/britive-client-go/entity-environment.go
@@ -34,6 +34,11 @@ func (c *Client) CreateEntityEnvironment(applicationEntity ApplicationEntityEnvi
 		return nil, err
 	}
 
+	c.CacheEvict(
+		fmt.Sprintf("root-env-group:%s", applicationID),
+		fmt.Sprintf("app-envs:%s:environments", applicationID),
+	)
+
 	return ae, nil
 }
 
@@ -47,6 +52,10 @@ func (c *Client) DeleteEntityEnvironment(applicationID, entityID string) error {
 
 	_, err = c.DoWithLock(req, applicationID)
 	if errors.Is(err, ErrNoContent) || err == nil {
+		c.CacheEvict(
+			fmt.Sprintf("root-env-group:%s", applicationID),
+			fmt.Sprintf("app-envs:%s:environments", applicationID),
+		)
 		return nil
 	}
 

--- a/britive-client-go/entity-group.go
+++ b/britive-client-go/entity-group.go
@@ -34,6 +34,11 @@ func (c *Client) CreateEntityGroup(applicationEntity ApplicationEntityGroup, app
 		return nil, err
 	}
 
+	c.CacheEvict(
+		fmt.Sprintf("root-env-group:%s", applicationID),
+		fmt.Sprintf("app-envs:%s:environmentGroups", applicationID),
+	)
+
 	return ae, nil
 }
 
@@ -63,6 +68,11 @@ func (c *Client) UpdateEntityGroup(applicationEntity ApplicationEntityGroup, app
 		return nil, err
 	}
 
+	c.CacheEvict(
+		fmt.Sprintf("root-env-group:%s", applicationID),
+		fmt.Sprintf("app-envs:%s:environmentGroups", applicationID),
+	)
+
 	return ae, nil
 }
 
@@ -76,6 +86,10 @@ func (c *Client) DeleteEntityGroup(applicationID, entityID string) error {
 
 	_, err = c.DoWithLock(req, applicationID)
 	if errors.Is(err, ErrNoContent) || err == nil {
+		c.CacheEvict(
+			fmt.Sprintf("root-env-group:%s", applicationID),
+			fmt.Sprintf("app-envs:%s:environmentGroups", applicationID),
+		)
 		return nil
 	}
 

--- a/britive-client-go/models.go
+++ b/britive-client-go/models.go
@@ -2,8 +2,9 @@ package britive
 
 // Config - godoc
 type Config struct {
-	Tenant string `json:"tenant"`
-	Token  string `json:"token"`
+	Tenant      string `json:"tenant"`
+	Token       string `json:"token"`
+	EnableCache bool   `json:"enable_cache"`
 }
 
 // HTTPErrorResponse - godoc

--- a/britive-client-go/profile-association.go
+++ b/britive-client-go/profile-association.go
@@ -90,6 +90,13 @@ func (c *Client) SaveProfileAssociationResourceScopes(profileID string, associat
 
 // Get the application type for a given application ID
 func (c *Client) GetApplicationType(appContainerID string) (*ApplicationType, error) {
+	cacheKey := fmt.Sprintf("app-type:%s", appContainerID)
+	if cached, ok := c.cacheGet(cacheKey); ok {
+		original := cached.(*ApplicationType)
+		cp := *original
+		return &cp, nil
+	}
+
 	resourceURL := fmt.Sprintf("%s/apps/%s", c.APIBaseURL, appContainerID)
 	req, err := http.NewRequest("GET", resourceURL, nil)
 	if err != nil {
@@ -111,6 +118,7 @@ func (c *Client) GetApplicationType(appContainerID string) (*ApplicationType, er
 		return nil, err
 	}
 
+	c.cacheSet(cacheKey, applicationType)
 	return applicationType, nil
 }
 

--- a/britive/provider.go
+++ b/britive/provider.go
@@ -85,6 +85,12 @@ func Provider(v string) *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("BRITIVE_CONFIG", "~/.britive/tf.config"),
 				Description: "This is the file path for Britive provider configuration. The default configuration path is ~/.britive/tf.config",
 			},
+			"enable_cache": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("BRITIVE_CACHE", false),
+				Description: "Enable in-memory caching of API responses to reduce redundant API calls during plan/apply. Defaults to false.",
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"britive_tag":                                            resourceTag.Resource,
@@ -128,23 +134,23 @@ func Provider(v string) *schema.Provider {
 	}
 }
 
-func getProviderConfigurationFromFile(d *schema.ResourceData) (string, string, error) {
+func getProviderConfigurationFromFile(d *schema.ResourceData) (string, string, bool, error) {
 	log.Print("[DEBUG] Trying to load configuration from file")
 	if configPath, ok := d.GetOk("config_path"); ok && configPath.(string) != "" {
 		path, err := homedir.Expand(configPath.(string))
 		if err != nil {
 			log.Printf("[DEBUG] Failed to expand config file path %s, error %s", configPath, err)
-			return "", "", nil
+			return "", "", false, nil
 		}
 		if _, err := os.Stat(path); os.IsNotExist(err) {
 			log.Printf("[DEBUG] Terraform config file %s does not exist, error %s", path, err)
-			return "", "", nil
+			return "", "", false, nil
 		}
 		log.Printf("[DEBUG] Terraform configuration file is: %s", path)
 		configFile, err := os.Open(path)
 		if err != nil {
 			log.Printf("[DEBUG] Unable to open Terraform configuration file %s", path)
-			return "", "", fmt.Errorf("unable to open terraform configuration file. error %v", err)
+			return "", "", false, fmt.Errorf("unable to open terraform configuration file. error %v", err)
 		}
 		defer configFile.Close()
 
@@ -153,11 +159,11 @@ func getProviderConfigurationFromFile(d *schema.ResourceData) (string, string, e
 		err = json.Unmarshal(configBytes, &config)
 		if err != nil {
 			log.Printf("[DEBUG] Failed to parse config file %s", path)
-			return "", "", fmt.Errorf("invalid terraform configuration file format. error %v", err)
+			return "", "", false, fmt.Errorf("invalid terraform configuration file format. error %v", err)
 		}
-		return config.Tenant, config.Token, nil
+		return config.Tenant, config.Token, config.EnableCache, nil
 	}
-	return "", "", nil
+	return "", "", false, nil
 }
 
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
@@ -166,11 +172,17 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 
 	token := d.Get("token").(string)
 	tenant := d.Get("tenant").(string)
+	enableCache := d.Get("enable_cache").(bool)
 
 	if tenant == "" && token == "" {
-		tenant, token, err = getProviderConfigurationFromFile(d)
+		var fileCacheEnabled bool
+		tenant, token, fileCacheEnabled, err = getProviderConfigurationFromFile(d)
 		if err != nil {
 			return nil, diag.FromErr(err)
+		}
+		// Config file value is used only as a fallback; explicit provider attribute or env var takes precedence
+		if !enableCache {
+			enableCache = fileCacheEnabled
 		}
 	}
 	if tenant == "" {
@@ -190,7 +202,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	}
 
 	apiBaseURL := fmt.Sprintf("%s/api", strings.TrimSuffix(tenant, "/"))
-	c, err := britive.NewClient(apiBaseURL, token, version)
+	c, err := britive.NewClient(apiBaseURL, token, version, enableCache)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,

--- a/docs/data-sources/all_connections.md
+++ b/docs/data-sources/all_connections.md
@@ -25,14 +25,14 @@ output "all_connections" {
 
 The following argument is supported:
 
-- `setting_type` (Optional) – The type of advanced setting. Defaults to 'ITSM' if not specified. Supported types are ITSM and IM.
+- `setting_type` (Optional) - The type of advanced setting. Defaults to 'ITSM' if not specified. Supported types are ITSM and IM.
 
 ## Attribute Reference
 
 The following attributes are exported:
 
-- `connections` – A set of all connections, each containing:
-  - `id` – The unique identifier of the connection.
-  - `name` – The name of the connection.
-  - `type` – The type of the connection.
-  - `auth_type` – The authentication type of the connection.
+- `connections` - A set of all connections, each containing:
+  - `id` - The unique identifier of the connection.
+  - `name` - The name of the connection.
+  - `type` - The type of the connection.
+  - `auth_type` - The authentication type of the connection.

--- a/docs/data-sources/connection.md
+++ b/docs/data-sources/connection.md
@@ -39,14 +39,14 @@ output "connection_auth_type" {
 
 The following argument is supported:
 
-- `name` (Required) – The name of the connection to retrieve.
-- `setting_type` (Optional) – The type of advanced setting. Defaults to 'ITSM' if not specified. Supported types are ITSM and IM.
+- `name` (Required) - The name of the connection to retrieve.
+- `setting_type` (Optional) - The type of advanced setting. Defaults to 'ITSM' if not specified. Supported types are ITSM and IM.
 
 ## Attribute Reference
 
 The following attributes are exported:
 
-- `id` – The unique identifier of the connection.
-- `name` – The name of the connection.
-- `type` – The type of the connection.
-- `auth_type` – The authentication type of the connection.
+- `id` - The unique identifier of the connection.
+- `name` - The name of the connection.
+- `type` - The type of the connection.
+- `auth_type` - The authentication type of the connection.

--- a/docs/data-sources/escalation_policy.md
+++ b/docs/data-sources/escalation_policy.md
@@ -27,11 +27,11 @@ output "policy_id" {
 
 The following argument is supported:
 
-- `name` (Required) – The name of the escalation to retrieve.
-- `im_connection_id` (Required) – Id of IM connection.
+- `name` (Required) - The name of the escalation to retrieve.
+- `im_connection_id` (Required) - Id of IM connection.
 
 ## Attribute Reference
 
 The following attributes are exported:
 
-- `id` – The unique identifier of the escalation policy.
+- `id` - The unique identifier of the escalation policy.

--- a/docs/data-sources/resource_manager_profile_permissions.md
+++ b/docs/data-sources/resource_manager_profile_permissions.md
@@ -26,13 +26,13 @@ output "permissions" {
 
 The following argument is supported:
 
-- `profile_id` (Required) – The unique identifier of the profile.
+- `profile_id` (Required) - The unique identifier of the profile.
 
 ## Attribute Reference
 
 The following attributes are exported:
 
-- `permissions` – A list of permissions available for the specified profile.
-    - `name` – The name of the permission.
-    - `permission_id` – The unique identifier of the permission.
-    - `version` – A list of available versions of the permission.
+- `permissions` - A list of permissions available for the specified profile.
+    - `name` - The name of the permission.
+    - `permission_id` - The unique identifier of the permission.
+    - `version` - A list of available versions of the permission.

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,13 +62,20 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 
 * `config_path` - (Optional) This is the file path for Britive provider configuration. The default configuration path is `~/.britive/tf.config`. It can also be sourced from the `BRITIVE_CONFIG` environment variable.
 
+* `enable_cache` - (Optional) Enable in-memory caching of API responses to reduce redundant API calls during plan/apply. This is particularly useful for configurations with many profiles, profile policies, or entity resources that share the same application, as it avoids repeated lookups of root environment group data. Defaults to `false`. It can also be sourced from the `BRITIVE_CACHE` environment variable.
+
   A sample Britive configuration file is given below.
   
   ```json
   {
     "tenant": "https://company.britive.com",
-    "token": "xxxx"
+    "token": "xxxx",
+    "enable_cache": true
   }
   ```
 
 ~> If you have **both** valid configurations in a config file and provider config, then the provider config will override its counterpart loaded from the config file.
+
+## Rate Limit Handling
+
+The provider automatically retries API requests that receive an HTTP 429 (Too Many Requests) response from the Britive platform. When a 429 is received, the provider respects the `Retry-After` header returned by the API to determine how long to wait before retrying. Requests are retried up to 5 times before returning an error. This behavior is always enabled and requires no configuration.

--- a/docs/resources/advanced_settings.md
+++ b/docs/resources/advanced_settings.md
@@ -18,11 +18,11 @@ The `britive_advanced_settings` resource allows you to configure and manage adva
 
 This resource supports advanced settings for the following resource types:
 
-- `APPLICATION` – Britive application resource
-- `PROFILE` – Britive application profile resource
-- `PROFILE_POLICY` – Britive application profile policy resource
-- `RESOURCE_MANAGER_PROFILE` – Britive resource manager profile resource
-- `RESOURCE_MANAGER_PROFILE_POLICY` – Britive resource manager profile policy resource
+- `APPLICATION` - Britive application resource
+- `PROFILE` - Britive application profile resource
+- `PROFILE_POLICY` - Britive application profile policy resource
+- `RESOURCE_MANAGER_PROFILE` - Britive resource manager profile resource
+- `RESOURCE_MANAGER_PROFILE_POLICY` - Britive resource manager profile policy resource
 
 ## Example Usage
 
@@ -64,25 +64,25 @@ resource "britive_advanced_settings" "example" {
 
 The following arguments are supported:
 
-- `resource_id` (Required, ForceNew) – The unique identifier of the resource for which advanced settings are being managed.
-- `resource_type` (Required, ForceNew) – The type of resource. Must be one of: `APPLICATION`, `PROFILE`, `PROFILE_POLICY`, `RESOURCE_MANAGER_PROFILE` or `RESOURCE_MANAGER_PROFILE_POLICY`.
+- `resource_id` (Required, ForceNew) - The unique identifier of the resource for which advanced settings are being managed.
+- `resource_type` (Required, ForceNew) - The type of resource. Must be one of: `APPLICATION`, `PROFILE`, `PROFILE_POLICY`, `RESOURCE_MANAGER_PROFILE` or `RESOURCE_MANAGER_PROFILE_POLICY`.
 - `justification_settings` (Optional):
-  - `justification_id` (Computed) – The ID of the justification setting.
-  - `is_justification_required` (Required) – Whether justification is required for actions on the resource.
-  - `justification_regex` (Optional) – A regular expression to validate justification input.
+  - `justification_id` (Computed) - The ID of the justification setting.
+  - `is_justification_required` (Required) - Whether justification is required for actions on the resource.
+  - `justification_regex` (Optional) - A regular expression to validate justification input.
 - `itsm` (Optional):
-  - `itsm_id` (Computed) – The ID of the ITSM setting.
-  - `connection_id` (Required) – The ID of the ITSM connection.
-  - `connection_type` (Required) – The type of ITSM connection (e.g., Jira, ServiceNow).
-  - `is_itsm_enabled` (Required) – Whether ITSM integration is enabled.
+  - `itsm_id` (Computed) - The ID of the ITSM setting.
+  - `connection_id` (Required) - The ID of the ITSM connection.
+  - `connection_type` (Required) - The type of ITSM connection (e.g., Jira, ServiceNow).
+  - `is_itsm_enabled` (Required) - Whether ITSM integration is enabled.
   - `itsm_filter_criteria` (Required):
-      - `filter` (Required) – The filter definition (e.g., JQL for Jira).
-      - `supported_ticket_type` (Required) – The supported ticket type for the filter criteria. Example: `"issue"`, `"request"`.
+      - `filter` (Required) - The filter definition (e.g., JQL for Jira).
+      - `supported_ticket_type` (Required) - The supported ticket type for the filter criteria. Example: `"issue"`, `"request"`.
 - `im` (Optional):
-  - `connection_id` (Required) – The ID of the IM connection.
-  - `connection_type` (Required) – The type of IM connection (e.g., PagerDuty).
-  - `is_auto_approval_enabled` (Required) – Whether IM settings auto approval enabled.
-  - `escalation_policies` (Required) – Escalation policies of incident management setting.
+  - `connection_id` (Required) - The ID of the IM connection.
+  - `connection_type` (Required) - The type of IM connection (e.g., PagerDuty).
+  - `is_auto_approval_enabled` (Required) - Whether IM settings auto approval enabled.
+  - `escalation_policies` (Required) - Escalation policies of incident management setting.
 
 ## Resource Type Examples
 


### PR DESCRIPTION
Add in-memory caching for frequently repeated API calls (GetApplicationRootEnvironmentGroup, GetAppEnvs, GetApplicationType) to eliminate redundant GET requests during plan/apply. Caching is opt-in via the new enable_cache provider attribute, BRITIVE_CACHE env var, or config file.

Add automatic retry with Retry-After header support when the Britive API returns HTTP 429 (Too Many Requests). Retries up to 5 times with exponential backoff as fallback. Always enabled, no configuration needed.